### PR TITLE
change File::Basename rquired version. add Data::Printer to PREREQ_PM

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -14,8 +14,9 @@ WriteMakefile(
         'JSON::XS'              => 3.04,
         'HTTP::Request'         => 6.00,
         'Net::Google::OAuth'    => 0.03,
-        'File::Basename'        => 2.85,
+        'File::Basename'        => 2.84,
         'File::Spec'            => 3.48,
+        'Data::Printer'         => 0,
     },
     META_MERGE   => {
           requires  => { perl => '5.008008' },


### PR DESCRIPTION
File::Basename 2.85 requires Perl 5.30.
But I try to change Makefile.PL to allow File::Basename 2.84, all tests are passed.
So, If there is no reason why it must be 2.85, it is safe to specify 2.84 instead.
And it has already  listed in issues, Data::Printer is required but not in PREREQ_PM.
I added it in this patch.

Thanks.